### PR TITLE
Update registry.md

### DIFF
--- a/docs/zh_cn/understand_mmcv/registry.md
+++ b/docs/zh_cn/understand_mmcv/registry.md
@@ -56,7 +56,7 @@ from .converter1 import Converter1
 
 # 使用注册器管理模块
 @CONVERTERS.register_module()
-def converter2(a, b)
+def converter2(a, b):
     return Converter1(a, b)
 ```
 


### PR DESCRIPTION
the lack of colon(:)  

# 使用注册器管理模块
@CONVERTERS.register_module()
def converter2(a, b):
    return Converter1(a, b)
